### PR TITLE
chore: add demo mailchimp signup

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "date-fns": "2.16.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
+    "react-mailchimp-subscribe": "^2.1.3",
     "react-transition-group": "4.4.1",
     "throttle-debounce": "3.0.1",
     "typescript": "4.0.5",

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -5,6 +5,46 @@ import PageLayout from "@theme/PageLayout"
 import Button from "@theme/Button"
 import seCss from "../css/section.module.css"
 import paCss from "../css/community/page.module.css"
+import MailchimpSubscribe from "react-mailchimp-subscribe"
+
+const url =
+  "https://questdb.us7.list-manage.com/subscribe/post?u=f692ae4038a31e8ae997a0f29&amp;id=bdd4ec2744"
+
+// FIXME, disabling linter during testing
+/* eslint-disable react/prop-types */
+
+const CustomForm = ({ status, message, onValidated }) => {
+  let email
+  const submit = () =>
+    email != null &&
+    email.value.indexOf("@") > -1 &&
+    onValidated({
+      EMAIL: email.value,
+    })
+
+  return (
+    <div>
+      <input
+        className={paCss.custom_input}
+        ref={(node) => (email = node)}
+        type="email"
+        placeholder="Email address"
+      />
+      <Button onClick={submit} className={paCss.signup_button}>
+        Sign Up
+      </Button>
+      {status === "sending" && <div>sending...</div>}
+      {status === "error" && (
+        <div dangerouslySetInnerHTML={{ __html: message }} />
+      )}
+      {status === "success" && (
+        <div dangerouslySetInnerHTML={{ __html: message }} />
+      )}
+    </div>
+  )
+}
+
+/* eslint-enable react/prop-types */
 
 type Contribute = {
   image: string
@@ -66,12 +106,16 @@ const Community = () => {
                 Stay up to date with all things QuestDB
               </p>
               <div>
-                <input
-                  type="text"
-                  className={paCss.custom_input}
-                  placeholder="Email address"
+                <MailchimpSubscribe
+                  url={url}
+                  render={({ subscribe, status, message }) => (
+                    <CustomForm
+                      status={status}
+                      message={message}
+                      onValidated={(formData) => subscribe(formData)}
+                    />
+                  )}
                 />
-                <Button className={paCss.signup_button}>Sign Up</Button>
               </div>
             </div>
           </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4213,7 +4213,7 @@ date-fns@2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -7449,6 +7449,13 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  integrity sha1-pltPoPEL2nGaBUQep7lMVfPhW64=
+  dependencies:
+    debug "^2.1.3"
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz#642f1d7b88aa6d7eb9d8f2210e166478444fa891"
@@ -10045,7 +10052,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.0, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10338,6 +10345,15 @@ react-loadable@^5.5.0:
   integrity sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==
   dependencies:
     prop-types "^15.5.0"
+
+react-mailchimp-subscribe@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/react-mailchimp-subscribe/-/react-mailchimp-subscribe-2.1.3.tgz#2f195f20b98c9be9608fac95d1f4f5bcb2d81929"
+  integrity sha512-ZRuPZMnX/9pHQLnAQavsgB5xIF+gNqjNCCq1vvTs23cn+93W2oOp17qjg3LpDBEt1HJi6IHXMwpKXn0taY8FHw==
+  dependencies:
+    jsonp "^0.2.1"
+    prop-types "^15.5.10"
+    to-querystring "^1.0.4"
 
 react-router-config@^5.1.1:
   version "5.1.1"
@@ -12062,6 +12078,11 @@ to-object-path@^0.3.0:
   integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
+
+to-querystring@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/to-querystring/-/to-querystring-1.1.1.tgz#98de5b00c79768a98ca48a2c09a960238d960265"
+  integrity sha512-ZgIacl9TXAoT7sGXUYjQiy0MW7Tf/7CJQLt757hYHfXXc8JBzOVBMx4DckqKUO4hi36J72/m8UcH/GCHK+n97g==
 
 to-readable-stream@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hi Tin!

This PR adds functionality to the subscribe form to allow users to sign up to mailchimp. 

Prettier was throwing some errors for the `react/prop-types`, do you want to have a look? If you know of a better way to have this working, please feel free to make changes as it's not nice to have the prettier ignore rule here.

Thanks!